### PR TITLE
[TASK-16] docs(core): Implement ApiDataResponse and update swagger documentation

### DIFF
--- a/apps/mindsync/mindsync.gradle.kts
+++ b/apps/mindsync/mindsync.gradle.kts
@@ -22,12 +22,15 @@ dependencies {
     implementation("org.springframework.security:spring-security-oauth2-client")
     implementation("org.springframework.security:spring-security-oauth2-jose")
     implementation("org.springframework.security:spring-security-oauth2-resource-server")
-    implementation("org.springdoc:springdoc-openapi-webflux-ui")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.2.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-api:2.2.0")
+//    implementation("org.springdoc:springdoc-openapi-webflux-ui")
     implementation(libs.moshi)
     implementation(libs.keycloak.admin.client)
 
     // 3 R D   P A R T Y
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     implementation(libs.bundles.reflections)
 

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/domain/Role.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/domain/Role.kt
@@ -45,7 +45,7 @@ enum class Role {
     companion object {
         private const val PREFIX = "ROLE_"
         private val ROLES: Map<String, Role> = buildRoles()
-        private fun buildRoles(): Map<String, Role> = values().associateBy { it.key() }
+        private fun buildRoles(): Map<String, Role> = entries.associateBy { it.key() }
 
         /**
          * Returns a [Role] object based on the provided role string. If the provided role string is blank,

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/SecurityConfiguration.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package io.mindsync.authentication.infrastructure
 
+import io.mindsync.authentication.domain.Role
 import io.mindsync.common.domain.Generated
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -137,6 +138,10 @@ class SecurityConfiguration(
                     .pathMatchers("/v3/api-docs.yaml").permitAll()
                     .pathMatchers("/actuator/**").authenticated()
                     .pathMatchers("/api/**").authenticated()
+                    .pathMatchers("/management/health").permitAll()
+                    .pathMatchers("/management/info").permitAll()
+                    .pathMatchers("/management/prometheus").permitAll()
+                    .pathMatchers("/management/**").hasAuthority(Role.ADMIN.key())
             }
             .oauth2Login(withDefaults())
             .oauth2Client(withDefaults())

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/SecurityConfiguration.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/SecurityConfiguration.kt
@@ -86,6 +86,8 @@ class SecurityConfiguration(
                 .requestMatchers("/content/**")
                 .requestMatchers("/swagger-ui/**")
                 .requestMatchers("/swagger-ui.html")
+                .requestMatchers("/webjars/**")
+                .requestMatchers("/api-docs/**")
                 .requestMatchers("/v3/api-docs/**")
                 .requestMatchers("/test/**")
         }
@@ -126,6 +128,14 @@ class SecurityConfiguration(
                     .pathMatchers("/health-check").permitAll()
                     .pathMatchers("/api/register").permitAll()
                     .pathMatchers("/api/login").permitAll()
+                    .pathMatchers("/api/logout").permitAll()
+                    .pathMatchers("/swagger-ui/**").permitAll()
+                    .pathMatchers("/webjars/**").permitAll()
+                    .pathMatchers("/api-docs/**").permitAll()
+                    .pathMatchers("/swagger-ui.html").permitAll()
+                    .pathMatchers("/v3/api-docs/**").permitAll()
+                    .pathMatchers("/v3/api-docs.yaml").permitAll()
+                    .pathMatchers("/actuator/**").authenticated()
                     .pathMatchers("/api/**").authenticated()
             }
             .oauth2Login(withDefaults())

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
 
 /**
  * This class is a controller responsible for handling user authentication related requests.
@@ -24,6 +25,12 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api")
 class UserAuthenticatorController(private val authenticateUserQueryHandler: AuthenticateUserQueryHandler) {
 
+    /**
+     * Logs in a user with the provided username and password.
+     *
+     * @param loginRequest The login request containing the username and password.
+     * @return A Mono of ResponseEntity containing the response object with the access token.
+     */
     @Operation(summary = "Login endpoint")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "OK"),
@@ -31,13 +38,14 @@ class UserAuthenticatorController(private val authenticateUserQueryHandler: Auth
         ApiResponse(responseCode = "401", description = "Unauthorized"),
         ApiResponse(responseCode = "500", description = "Internal server error")
     )
-    @PostMapping("/login")
-    suspend fun login(@Validated @RequestBody loginRequest: LoginRequest): ResponseEntity<AccessToken> {
-        val authenticateUserQuery = AuthenticateUserQuery(
-            username = loginRequest.username,
-            password = loginRequest.password
-        )
+    @PostMapping(LOGIN_ROUTE)
+    suspend fun login(@Validated @RequestBody loginRequest: LoginRequest): Mono<ResponseEntity<AccessToken>> {
+        val (username, password) = loginRequest
+        val authenticateUserQuery = AuthenticateUserQuery(username = username, password = password)
         val accessToken = authenticateUserQueryHandler.handle(authenticateUserQuery)
-        return ResponseEntity.ok(accessToken)
+        return Mono.just(ResponseEntity.ok(accessToken))
+    }
+    companion object {
+        const val LOGIN_ROUTE = "/login"
     }
 }

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
@@ -4,6 +4,9 @@ import io.mindsync.authentication.application.AuthenticateUserQueryHandler
 import io.mindsync.authentication.application.query.AuthenticateUserQuery
 import io.mindsync.authentication.domain.AccessToken
 import io.mindsync.authentication.infrastructure.http.request.LoginRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
@@ -21,6 +24,13 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api")
 class UserAuthenticatorController(private val authenticateUserQueryHandler: AuthenticateUserQueryHandler) {
 
+    @Operation(summary = "Login endpoint")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "OK"),
+        ApiResponse(responseCode = "401", description = "Unauthorized"),
+        ApiResponse(responseCode = "400", description = "Bad request"),
+        ApiResponse(responseCode = "500", description = "Internal server error")
+    )
     @PostMapping("/login")
     suspend fun login(@Validated @RequestBody loginRequest: LoginRequest): ResponseEntity<AccessToken> {
         val authenticateUserQuery = AuthenticateUserQuery(

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
@@ -27,8 +27,8 @@ class UserAuthenticatorController(private val authenticateUserQueryHandler: Auth
     @Operation(summary = "Login endpoint")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "OK"),
-        ApiResponse(responseCode = "401", description = "Unauthorized"),
         ApiResponse(responseCode = "400", description = "Bad request"),
+        ApiResponse(responseCode = "401", description = "Unauthorized"),
         ApiResponse(responseCode = "500", description = "Internal server error")
     )
     @PostMapping("/login")

--- a/apps/mindsync/src/main/kotlin/io/mindsync/config/ObjectMapperConfig.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/config/ObjectMapperConfig.kt
@@ -1,0 +1,35 @@
+package io.mindsync.config
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+
+@Configuration
+class ObjectMapperConfig {
+
+    @Bean
+    @Primary
+    fun objectMapper(): JsonMapper {
+        val kotlinModule = KotlinModule.Builder()
+            .enable(KotlinFeature.StrictNullChecks)
+            .build()
+        val mapper = JsonMapper.builder()
+            .addModule(kotlinModule)
+            .build()
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+        val javaTimeModule = JavaTimeModule()
+        mapper.registerModule(javaTimeModule)
+
+        return mapper
+    }
+}

--- a/apps/mindsync/src/main/kotlin/io/mindsync/config/ObjectMapperConfig.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/config/ObjectMapperConfig.kt
@@ -2,6 +2,7 @@ package io.mindsync.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -25,6 +26,7 @@ class ObjectMapperConfig {
             .build()
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
         val javaTimeModule = JavaTimeModule()

--- a/apps/mindsync/src/main/kotlin/io/mindsync/config/springdoc/SpringdocConfiguration.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/config/springdoc/SpringdocConfiguration.kt
@@ -3,6 +3,7 @@ package io.mindsync.config.springdoc
 import io.mindsync.common.domain.Generated
 import io.swagger.v3.oas.models.ExternalDocumentation
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.info.License
 import org.springdoc.core.GroupedOpenApi
@@ -26,9 +27,15 @@ import org.springframework.context.annotation.Configuration
  */
 @Configuration
 @Generated(reason = "Not testing technical configuration")
-internal class SpringdocConfiguration {
+class SpringdocConfiguration {
     @Value("\${application.version:undefined}")
     private val version: String? = null
+
+    @Value("\${application.name:MindSync}")
+    private val name: String? = null
+
+    @Value("\${application.description:undefined}")
+    private val description: String? = null
 
     @Bean
     fun mindsyncOpenAPI(): OpenAPI {
@@ -36,7 +43,9 @@ internal class SpringdocConfiguration {
     }
 
     private fun swaggerInfo(): Info {
-        return Info().title("Project API").description("Project description API").version(version)
+        val contact = Contact().name("Yuniel Acosta").url("www.yunielacosta.com").email("ylaz@gft.com")
+        return Info().title("${name?.uppercase()} API").description(description).version(version)
+            .contact(contact)
             .license(License().name("No license").url(""))
     }
 

--- a/apps/mindsync/src/main/kotlin/io/mindsync/error/GlobalExceptionHandler.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/error/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package io.mindsync.error
 
+import io.mindsync.common.domain.error.BusinessRuleValidationException
 import io.mindsync.users.domain.exceptions.UserAuthenticationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
@@ -33,6 +34,31 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         problemDetail.title = "User authentication failed"
         problemDetail.setType(URI.create("https://mindsync.io/errors/user-authentication-failed"))
         problemDetail.setProperty("errorCategory", "AUTHENTICATION")
+        problemDetail.setProperty("timestamp", Instant.now())
+        return problemDetail
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException::class, BusinessRuleValidationException::class)
+    fun handleIllegalArgumentException(e: Exception): ProblemDetail {
+        val problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.message ?: "Bad request")
+        problemDetail.title = "Bad request"
+        problemDetail.setType(URI.create("https://mindsync.io/errors/bad-request"))
+        problemDetail.setProperty("errorCategory", "BAD_REQUEST")
+        problemDetail.setProperty("timestamp", Instant.now())
+        return problemDetail
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ProblemDetail {
+        val problemDetail = ProblemDetail.forStatusAndDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            e.message ?: "Internal server error"
+        )
+        problemDetail.title = "Internal server error"
+        problemDetail.setType(URI.create("https://mindsync.io/errors/internal-server-error"))
+        problemDetail.setProperty("errorCategory", "INTERNAL_SERVER_ERROR")
         problemDetail.setProperty("timestamp", Instant.now())
         return problemDetail
     }

--- a/apps/mindsync/src/main/kotlin/io/mindsync/healthcheck/HealthcheckController.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/healthcheck/HealthcheckController.kt
@@ -1,5 +1,8 @@
 package io.mindsync.healthcheck
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -21,6 +24,11 @@ class HealthcheckController {
      *
      * @return a Mono emitting a string "OK" indicating that the application is healthy.
      */
+    @Operation(summary = "Health check endpoint")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "OK"),
+        ApiResponse(responseCode = "500", description = "Internal server error")
+    )
     @GetMapping
     fun healthcheck(): Mono<String> = Mono.just("OK")
 }

--- a/apps/mindsync/src/main/kotlin/io/mindsync/users/application/UserRegistrator.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/users/application/UserRegistrator.kt
@@ -5,7 +5,7 @@ import io.mindsync.common.domain.error.BusinessRuleValidationException
 import io.mindsync.event.domain.EventBroadcaster
 import io.mindsync.event.domain.EventPublisher
 import io.mindsync.users.application.command.RegisterUserCommand
-import io.mindsync.users.domain.ApiResponse
+import io.mindsync.users.domain.ApiDataResponse
 import io.mindsync.users.domain.User
 import io.mindsync.users.domain.UserCreator
 import io.mindsync.users.domain.event.UserCreatedEvent
@@ -24,7 +24,7 @@ class UserRegistrator(
         this.eventPublisher.use(eventPublisher)
     }
 
-    suspend fun registerNewUser(registerUserCommand: RegisterUserCommand): Mono<ApiResponse<UserResponse>> {
+    suspend fun registerNewUser(registerUserCommand: RegisterUserCommand): Mono<ApiDataResponse<UserResponse>> {
         log.info(
             "Registering new user with email: {}",
             registerUserCommand.email
@@ -43,15 +43,15 @@ class UserRegistrator(
                         createdUser.name?.lastName?.value
                     )
 
-                    ApiResponse.success(userResponse)
+                    ApiDataResponse.success(userResponse)
                 }
                 .onErrorResume { throwable ->
                     log.error("Failed to register new user", throwable)
-                    Mono.just(ApiResponse.failure("Failed to register new user. Please try again."))
+                    Mono.just(ApiDataResponse.failure("Failed to register new user. Please try again."))
                 }
         } catch (e: BusinessRuleValidationException) {
             log.error("Failed to register new user", e)
-            Mono.just(ApiResponse.failure(e.message))
+            Mono.just(ApiDataResponse.failure(e.message))
         }
     }
 

--- a/apps/mindsync/src/main/kotlin/io/mindsync/users/domain/ApiDataResponse.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/users/domain/ApiDataResponse.kt
@@ -6,18 +6,18 @@ enum class ApiResponseStatus {
     FAILURE
 }
 
-data class ApiResponse<T>(
+data class ApiDataResponse<T>(
     val status: ApiResponseStatus,
     val data: T? = null,
     val error: String? = null
 ) : Response {
     companion object {
-        fun <T> success(data: T): ApiResponse<T> {
-            return ApiResponse(ApiResponseStatus.SUCCESS, data)
+        fun <T> success(data: T): ApiDataResponse<T> {
+            return ApiDataResponse(ApiResponseStatus.SUCCESS, data)
         }
 
-        fun <T> failure(error: String): ApiResponse<T> {
-            return ApiResponse(ApiResponseStatus.FAILURE, error = error)
+        fun <T> failure(error: String): ApiDataResponse<T> {
+            return ApiDataResponse(ApiResponseStatus.FAILURE, error = error)
         }
     }
 }

--- a/apps/mindsync/src/main/resources/application.yml
+++ b/apps/mindsync/src/main/resources/application.yml
@@ -62,3 +62,5 @@ springdoc:
     swagger-ui:
         enabled: true
         path: /api-docs
+        csrf:
+            enabled: true

--- a/apps/mindsync/src/main/resources/application.yml
+++ b/apps/mindsync/src/main/resources/application.yml
@@ -7,7 +7,7 @@ logging:
         org.springframework.security: DEBUG
 spring:
     application:
-        name: mindsync
+        name: ${application.name}
     main:
         allow-bean-definition-overriding: true
     profiles:
@@ -30,6 +30,8 @@ spring:
             password: ${NEO4J_PASSWORD:margin-saturn-presto-saga-slogan-8117}
 
 application:
+    name: mindsync
+    description: MindSync is the take note of the future. It's a note taking app that uses AI to help you take notes.
     version: 0.0.1-SNAPSHOT
     security:
         oauth2:
@@ -51,4 +53,12 @@ management:
     endpoints:
         web:
             exposure:
-                include: info, health, beans
+                include: info, health, beans, openapi, swagger-ui
+# swagger-ui custom path
+springdoc:
+    show-actuator: true
+    api-docs:
+        enabled: true
+    swagger-ui:
+        enabled: true
+        path: /api-docs

--- a/apps/mindsync/src/test/kotlin/io/mindsync/users/application/UserRegistratorTest.kt
+++ b/apps/mindsync/src/test/kotlin/io/mindsync/users/application/UserRegistratorTest.kt
@@ -3,7 +3,7 @@ package io.mindsync.users.application
 import io.kotest.common.runBlocking
 import io.mindsync.UnitTest
 import io.mindsync.users.application.command.RegisterUserCommand
-import io.mindsync.users.domain.ApiResponse
+import io.mindsync.users.domain.ApiDataResponse
 import io.mindsync.users.domain.ApiResponseStatus
 import io.mindsync.users.domain.Credential
 import io.mindsync.users.domain.event.UserCreatedEvent
@@ -31,7 +31,7 @@ class UserRegistratorTest {
         val registerUserCommand = createRegisterUserCommand()
 
         runBlocking {
-            val result: Mono<ApiResponse<UserResponse>> =
+            val result: Mono<ApiDataResponse<UserResponse>> =
                 userRegistrator.registerNewUser(registerUserCommand)
 
             val response = result.block()
@@ -50,7 +50,7 @@ class UserRegistratorTest {
         val invalidEmail = "test"
         val registerUserCommand = createRegisterUserCommand(email = invalidEmail)
 
-        val result: Mono<ApiResponse<UserResponse>> =
+        val result: Mono<ApiDataResponse<UserResponse>> =
             userRegistrator.registerNewUser(registerUserCommand)
 
         val response = result.block()
@@ -68,7 +68,7 @@ class UserRegistratorTest {
         val invalidPassword = "ab@W"
         val registerUserCommand = createRegisterUserCommand(password = invalidPassword)
 
-        val result: Mono<ApiResponse<UserResponse>> =
+        val result: Mono<ApiDataResponse<UserResponse>> =
             userRegistrator.registerNewUser(registerUserCommand)
 
         val response = result.block()
@@ -86,7 +86,7 @@ class UserRegistratorTest {
         val invalidFirstname = "ab!@#$%^&*()_+"
         val registerUserCommand = createRegisterUserCommand(firstname = invalidFirstname)
 
-        val result: Mono<ApiResponse<UserResponse>> =
+        val result: Mono<ApiDataResponse<UserResponse>> =
             userRegistrator.registerNewUser(registerUserCommand)
 
         val response = result.block()
@@ -106,7 +106,7 @@ class UserRegistratorTest {
         val invalidLastname = (charUppercase + charLowercase).shuffled().joinToString("").repeat(4)
         val registerUserCommand = createRegisterUserCommand(lastname = invalidLastname)
 
-        val result: Mono<ApiResponse<UserResponse>> =
+        val result: Mono<ApiDataResponse<UserResponse>> =
             userRegistrator.registerNewUser(registerUserCommand)
 
         val response = result.block()
@@ -123,7 +123,7 @@ class UserRegistratorTest {
     fun `should not register new user with existing email`(): Unit = runBlocking {
         val registerUserCommand = createRegisterUserCommand(email = "test@google.com")
 
-        var result: Mono<ApiResponse<UserResponse>> =
+        var result: Mono<ApiDataResponse<UserResponse>> =
             userRegistrator.registerNewUser(registerUserCommand)
 
         var response = result.block()
@@ -154,7 +154,7 @@ class UserRegistratorTest {
         val registerUserCommand = createRegisterUserCommand()
 
         runBlocking {
-            val result: Mono<ApiResponse<UserResponse>> =
+            val result: Mono<ApiDataResponse<UserResponse>> =
                 userRegistrator.registerNewUser(registerUserCommand)
 
             val response = result.block()

--- a/apps/mindsync/src/test/kotlin/io/mindsync/users/infrastructure/http/UserRegisterControllerTest.kt
+++ b/apps/mindsync/src/test/kotlin/io/mindsync/users/infrastructure/http/UserRegisterControllerTest.kt
@@ -3,7 +3,7 @@ package io.mindsync.users.infrastructure.http
 import io.mindsync.UnitTest
 import io.mindsync.users.application.UserRegistrator
 import io.mindsync.users.application.UserResponse
-import io.mindsync.users.domain.ApiResponse
+import io.mindsync.users.domain.ApiDataResponse
 import io.mindsync.users.domain.ApiResponseStatus
 import io.mindsync.users.domain.exceptions.UserStoreException
 import io.mindsync.users.infrastructure.dto.RegisterUserRequest
@@ -37,9 +37,9 @@ class UserRegisterControllerTest {
     fun `should register user successfully`() = runBlocking {
         // Arrange
         val request = RegisterUserRequest(email, password, firstName, lastName)
-        val expectedApiResponse = ApiResponse.success(successResponse)
+        val expectedApiDataResponse = ApiDataResponse.success(successResponse)
 
-        coEvery { mockUserRegistrator.registerNewUser(any()) } returns Mono.just(expectedApiResponse)
+        coEvery { mockUserRegistrator.registerNewUser(any()) } returns Mono.just(expectedApiDataResponse)
 
         // Act & Assert
         webTestClient.post().uri(ENDPOINT)
@@ -59,9 +59,11 @@ class UserRegisterControllerTest {
     fun `should handle failed registration`() = runBlocking {
         // Arrange
         val request = RegisterUserRequest(email, password, firstName, lastName)
-        val expectedApiResponse = ApiResponse.failure<UserResponse>("Failed to register new user. Please try again.")
+        val expectedApiDataResponse = ApiDataResponse.failure<UserResponse>(
+            "Failed to register new user. Please try again."
+        )
 
-        coEvery { mockUserRegistrator.registerNewUser(any()) } returns Mono.just(expectedApiResponse)
+        coEvery { mockUserRegistrator.registerNewUser(any()) } returns Mono.just(expectedApiDataResponse)
 
         // Act & Assert
         webTestClient.post().uri(ENDPOINT)


### PR DESCRIPTION
The ApiResponse was renamed to ApiDataResponse for a better explanation of its purpose. ObjectMapperConfig was added to enhance JSON object mappings. Dependencies in mindsync.gradle.kts were updated along with changes in path of Swagger UI for springdoc in application.yml. Extended swagger documentation was implemented for individual API endpoints for a clear understanding of their functionality and expected response codes. Changes in UserRegisterController and UserRegistrator to accommodate ApiResponse to ApiDataResponse.

These changes will provide better readability and understanding of the application's APIs for the developers and users, assisting in easier tracking and user experience. It also helps in better categorization of request and response objects, further enhancing code organization.

Closes: #93