### PR TITLE
[TASK-31] [TASK-17] fix(auth): 🚨 Update README and refactor authentication system

### DIFF
--- a/apps/mindsync/README.md
+++ b/apps/mindsync/README.md
@@ -102,6 +102,9 @@ You can execute the following command to test the application with coverage:
 ./gradlew clean check sonar jacocoTestReport aggregateReports
 ```
 
+### 📄 Documentation
+
+The MindSync Backend Application is documented using Swagger. You can access the Swagger UI at [http://localhost:8080/api-docs](http://localhost:8080/api-docs) and the Swagger JSON at [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs).
 
 ### 🐉 Why Spring Webflux?
 

--- a/apps/mindsync/mindsync.gradle.kts
+++ b/apps/mindsync/mindsync.gradle.kts
@@ -22,9 +22,8 @@ dependencies {
     implementation("org.springframework.security:spring-security-oauth2-client")
     implementation("org.springframework.security:spring-security-oauth2-jose")
     implementation("org.springframework.security:spring-security-oauth2-resource-server")
-    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.2.0")
-    implementation("org.springdoc:springdoc-openapi-starter-webflux-api:2.2.0")
-//    implementation("org.springdoc:springdoc-openapi-webflux-ui")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-api")
     implementation(libs.moshi)
     implementation(libs.keycloak.admin.client)
 

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/ApplicationSecurityProperties.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/ApplicationSecurityProperties.kt
@@ -58,8 +58,8 @@ class ApplicationSecurityProperties(
             var audience: MutableList<String> = ArrayList()
         )
 
-        private val CONTENT_SECURITY_POLICY = """
-    default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' data: https://fonts.gstatic.com;
-        """.trimIndent()
+        @Suppress("MaxLineLength")
+        private const val CONTENT_SECURITY_POLICY =
+            "default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:"
     }
 }

--- a/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/authentication/infrastructure/http/UserAuthenticatorController.kt
@@ -22,7 +22,7 @@ import reactor.core.publisher.Mono
  * @created 31/7/23
  */
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api", produces = ["application/vnd.api.v1+json"])
 class UserAuthenticatorController(private val authenticateUserQueryHandler: AuthenticateUserQueryHandler) {
 
     /**

--- a/apps/mindsync/src/main/kotlin/io/mindsync/config/springdoc/SpringdocConfiguration.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/config/springdoc/SpringdocConfiguration.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.info.License
-import org.springdoc.core.GroupedOpenApi
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/apps/mindsync/src/main/kotlin/io/mindsync/users/infrastructure/http/UserRegisterController.kt
+++ b/apps/mindsync/src/main/kotlin/io/mindsync/users/infrastructure/http/UserRegisterController.kt
@@ -36,7 +36,7 @@ import reactor.core.publisher.Mono
  * @created 30/6/23
  */
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api", produces = ["application/vnd.api.v1+json"])
 class UserRegisterController(private val userRegistrator: UserRegistrator) {
 
     /**

--- a/apps/mindsync/src/main/resources/application.yml
+++ b/apps/mindsync/src/main/resources/application.yml
@@ -54,7 +54,7 @@ management:
         web:
             exposure:
                 include: info, health, beans, openapi, swagger-ui
-# swagger-ui custom path
+
 springdoc:
     show-actuator: true
     api-docs:

--- a/apps/mindsync/src/test/kotlin/io/mindsync/authentication/infrastructure/ApplicationSecurityPropertiesTest.kt
+++ b/apps/mindsync/src/test/kotlin/io/mindsync/authentication/infrastructure/ApplicationSecurityPropertiesTest.kt
@@ -26,6 +26,6 @@ internal class ApplicationSecurityPropertiesTest {
     companion object {
         @Suppress("MaxLineLength")
         private const val DEFAULT_CONTENT_SECURITY_POLICY =
-            "default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' data: https://fonts.gstatic.com;"
+            "default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:"
     }
 }

--- a/documentation/docs/resources/requests/auth.http
+++ b/documentation/docs/resources/requests/auth.http
@@ -1,0 +1,31 @@
+POST http://127.0.0.1:8080/api/register
+Accept: application/vnd.api.v1+json
+X-XSRF-TOKEN: 470b1cbc-ed68-4f16-a406-5e072e863d04
+Content-Type: application/json
+Cookie: XSRF-TOKEN=470b1cbc-ed68-4f16-a406-5e072e863d04
+
+{
+  "email": "random@gmail.com",
+  "password": "My5up3r5tr0ngP@55w0rd",
+  "firstname": "John",
+  "lastname": "Doe"
+}
+<> 2023-08-10T201918.201.json
+
+###
+
+POST http://127.0.0.1:8080/api/login
+Accept: application/vnd.api.v1+json
+X-XSRF-TOKEN: 470b1cbc-ed68-4f16-a406-5e072e863d04
+Content-Type: application/json
+Cookie: XSRF-TOKEN=470b1cbc-ed68-4f16-a406-5e072e863d04
+
+{
+  "username": "john.doe@mindsync.com",
+  "password": "S3cr3tP@ssw0rd*123"
+}
+
+<> 2023-08-10T202054.200.json
+
+###
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,8 @@ arrow = "1.2.0"
 sonarqubeGradlePlugin = "4.3.0.3225"
 jacoco = "0.8.10"
 mockk = "1.13.5"
-junit= "5.9.3"
-datafaker= "2.0.1"
+junit = "5.9.3"
+datafaker = "2.0.1"
 reactor = "3.5.8"
 kotest = "5.6.2"
 rest-assured = "5.3.1"
@@ -25,7 +25,7 @@ frontend-gradle-plugin = "7.0.0"
 buildtools-native = "0.9.24"
 moshi = "1.15.0"
 keycloak-admin-client = "22.0.1"
-springdoc-openapi-webflux-ui = "1.7.0"
+springdoc = "2.2.0"
 reflections = "0.10.2"
 
 [libraries]
@@ -41,7 +41,8 @@ springBoot-gradle = { module = "org.springframework.boot:spring-boot-gradle-plug
 springBoot-dependencyManagement = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springBoot" }
 spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "springBoot" }
-springdoc-openapi-webflux-ui = { module = "org.springdoc:springdoc-openapi-webflux-ui", version.ref = "springdoc-openapi-webflux-ui" }
+springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
+springdoc-openapi-starter-webflux-api = { module = "org.springdoc:springdoc-openapi-starter-webflux-api", version.ref = "springdoc" }
 dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 gradle-git-properties = { module = "com.gorylenko.gradle-git-properties:gradle-git-properties", version.ref = "gradle-git-properties" }
 detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
@@ -83,7 +84,7 @@ jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jsonweb
 
 
 [bundles]
-spring-boot = ["spring-boot-starter", "spring-boot-starter-webflux", "springdoc-openapi-webflux-ui"]
+spring-boot = ["spring-boot-starter", "spring-boot-starter-webflux", "springdoc-openapi-starter-webflux-ui", "springdoc-openapi-starter-webflux-api"]
 arrow = ["arrow-core", "arrow-fx-coroutines"]
 kotlinx-coroutines = ["kotlinx-coroutines-core", "kotlinx-coroutines-reactor", "kotlinx-coroutines-reactive", "kotlinx-coroutines-jdk8"]
 reflections = ["reflections", "kotlin-reflect"]


### PR DESCRIPTION
Enhanced documentation by adding details about the MindSync Backend Application Swagger. Updated the UserAuthenticatorController, UserRegisterController, and auth.http to ensure they produce application/vnd.api.v1+json output. Refactored SecurityConfiguration to replace web security settings customizer with web exchange matcher for more explicit exclusions, thus aligning it better with reactive programming principles. This results in an improved, non-blocking, and more efficient back-pressure algorithm.

Closes: #95 